### PR TITLE
fix: update output type in config and extend connection lifetime

### DIFF
--- a/cmd/config.yaml
+++ b/cmd/config.yaml
@@ -5,7 +5,7 @@ btf:
   kernel: "/sys/kernel/btf/vmlinux"
 
 output:
-  type: clickhouse
+  type: file
   clickhouse:
     host: "192.168.200.201"
     port: "9000"

--- a/pkg/client/clickhouse.go
+++ b/pkg/client/clickhouse.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/cen-ngc5139/shepherd/internal/config"
@@ -21,7 +22,7 @@ func NewClickHouseConn(cfg config.ClickhouseOutputConfig) (clickhouse.Conn, erro
 		Compression: &clickhouse.Compression{
 			Method: clickhouse.CompressionLZ4,
 		},
-		ConnMaxLifetime:  3600,
+		ConnMaxLifetime:  time.Hour * 3,
 		ConnOpenStrategy: clickhouse.ConnOpenInOrder,
 	})
 	if err != nil {


### PR DESCRIPTION
- Changed output type in `config.yaml` from Clickhouse to file to align with new data handling strategy.
- Increased `ConnMaxLifetime` in `clickhouse.go` from 3600 seconds to 3 hours for improved connection management.